### PR TITLE
Apply PR feedback

### DIFF
--- a/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogInternal.cs
+++ b/src/libraries/System.Diagnostics.EventLog/src/System/Diagnostics/EventLogInternal.cs
@@ -1348,7 +1348,6 @@ namespace System.Diagnostics
         private void InternalWriteEvent(uint eventID, ushort category, EventLogEntryType type, string[] strings,
                                 byte[] rawData, string currentMachineName)
         {
-            // check arguments
             if (strings == null)
                 strings = Array.Empty<string>();
             if (strings.Length >= 256)

--- a/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
+++ b/src/libraries/System.IO.Compression/src/System/IO/Compression/DeflateZLib/DeflateStream.cs
@@ -935,7 +935,6 @@ namespace System.IO.Compression
 
             public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
-                // Validate inputs
                 Debug.Assert(buffer != _arrayPoolBuffer);
                 _deflateStream.EnsureNotDisposed();
                 if (count <= 0)
@@ -984,7 +983,6 @@ namespace System.IO.Compression
 
             public override void Write(byte[] buffer, int offset, int count)
             {
-                // Validate inputs
                 Debug.Assert(buffer != _arrayPoolBuffer);
                 _deflateStream.EnsureNotDisposed();
 

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/Socket.cs
@@ -997,8 +997,6 @@ namespace System.Net.Sockets
         // Creates a new Sockets.Socket instance to handle an incoming connection.
         public Socket Accept()
         {
-            // Validate input parameters.
-
             ThrowIfDisposed();
 
             if (_rightEndPoint == null)
@@ -2152,7 +2150,6 @@ namespace System.Net.Sockets
         // Determines the status of a socket.
         public static void Select(IList? checkRead, IList? checkWrite, IList? checkError, int microSeconds)
         {
-            // Validate input parameters.
             if ((checkRead == null || checkRead.Count == 0) &&
                 (checkWrite == null || checkWrite.Count == 0) &&
                 (checkError == null || checkError.Count == 0))
@@ -2510,7 +2507,6 @@ namespace System.Net.Sockets
         // There's no direct equivalent of this in the Task APIs, so we mimic it here.
         private async Task<(Socket s, byte[] buffer, int bytesReceived)> AcceptAndReceiveHelperAsync(Socket? acceptSocket, int receiveSize)
         {
-            // Validate input parameters.
             if (receiveSize < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(receiveSize));

--- a/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
+++ b/src/libraries/System.Net.Sockets/src/System/Net/Sockets/UDPClient.cs
@@ -53,7 +53,6 @@ namespace System.Net.Sockets
         // specified port number.
         public UdpClient(int port, AddressFamily family)
         {
-            // Validate input parameters.
             if (!TcpValidationHelpers.ValidatePortNumber(port))
             {
                 throw new ArgumentOutOfRangeException(nameof(port));
@@ -360,7 +359,6 @@ namespace System.Net.Sockets
 
         public IAsyncResult BeginReceive(AsyncCallback? requestCallback, object? state)
         {
-            // Validate input parameters.
             ThrowIfDisposed();
 
             // Due to the nature of the ReceiveFrom() call and the ref parameter convention,
@@ -411,7 +409,6 @@ namespace System.Net.Sockets
         // Joins a multicast address group.
         public void JoinMulticastGroup(IPAddress multicastAddr)
         {
-            // Validate input parameters.
             ThrowIfDisposed();
             ArgumentNullException.ThrowIfNull(multicastAddr);
 
@@ -448,7 +445,6 @@ namespace System.Net.Sockets
         {
             ThrowIfDisposed();
 
-            // Validate input parameters.
             if (_family != AddressFamily.InterNetwork)
             {
                 throw new SocketException((int)SocketError.OperationNotSupported);
@@ -467,7 +463,6 @@ namespace System.Net.Sockets
         {
             ThrowIfDisposed();
 
-            // Validate input parameters.
             ArgumentNullException.ThrowIfNull(multicastAddr);
 
             if (ifindex < 0)
@@ -517,7 +512,6 @@ namespace System.Net.Sockets
         {
             ThrowIfDisposed();
 
-            // Validate input parameters.
             ArgumentNullException.ThrowIfNull(multicastAddr);
 
             // IPv6 Changes: we need to create the correct MulticastOption and
@@ -552,7 +546,6 @@ namespace System.Net.Sockets
         {
             ThrowIfDisposed();
 
-            // Validate input parameters.
             ArgumentNullException.ThrowIfNull(multicastAddr);
 
             if (ifindex < 0)

--- a/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/ASCIIEncoding.cs
@@ -77,8 +77,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-
             if (chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars, ExceptionResource.ArgumentNull_Array);
@@ -107,8 +105,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(string chars)
         {
-            // Validate input parameters
-
             if (chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars);
@@ -127,8 +123,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-
             if (chars == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars);
@@ -213,8 +207,6 @@ namespace System.Text
         public override unsafe int GetBytes(string chars, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            // Validate Parameters
-
             if (chars is null || bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -301,8 +293,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-
             if (chars == null || bytes == null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -432,8 +422,6 @@ namespace System.Text
 
         public override unsafe int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
@@ -462,8 +450,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-
             if (bytes == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
@@ -545,8 +531,6 @@ namespace System.Text
         public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-
             if (bytes is null || chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -585,8 +569,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-
             if (bytes is null || chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -715,8 +697,6 @@ namespace System.Text
 
         public override unsafe string GetString(byte[] bytes, int byteIndex, int byteCount)
         {
-            // Validate Parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Decoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Decoder.cs
@@ -102,7 +102,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate input parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count),
                       SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -172,7 +171,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (byteCount < 0 || charCount < 0)
                 throw new ArgumentOutOfRangeException(byteCount < 0 ? nameof(byteCount) : nameof(charCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -291,7 +289,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (byteCount < 0 || charCount < 0)
                 throw new ArgumentOutOfRangeException(byteCount < 0 ? nameof(byteCount) : nameof(charCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/DecoderNLS.cs
@@ -50,7 +50,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -93,7 +92,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (byteIndex < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(byteIndex < 0 ? nameof(byteIndex) : nameof(byteCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -177,7 +175,6 @@ namespace System.Text
                                               char* chars, int charCount, bool flush,
                                               out int bytesUsed, out int charsUsed, out bool completed)
         {
-            // Validate input parameters
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoder.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoder.cs
@@ -100,7 +100,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count),
                       SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -167,7 +166,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate input parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -286,7 +284,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate input parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/EncoderNLS.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/EncoderNLS.cs
@@ -46,7 +46,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count),
                       SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -68,7 +67,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count),
                       SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -168,7 +166,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate input parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Encoding.cs
@@ -585,7 +585,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count),
                       SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -720,7 +719,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate input parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -781,7 +779,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate input parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count),
                       SR.ArgumentOutOfRange_NeedNonNegNum);
@@ -856,7 +853,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (byteCount < 0 || charCount < 0)
                 throw new ArgumentOutOfRangeException(byteCount < 0 ? nameof(byteCount) : nameof(charCount),
                     SR.ArgumentOutOfRange_NeedNonNegNum);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/Latin1Encoding.cs
@@ -40,8 +40,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-
             if (chars == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars);
@@ -57,8 +55,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-
             if (chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars, ExceptionResource.ArgumentNull_Array);
@@ -92,8 +88,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(string s)
         {
-            // Validate input parameters
-
             if (s is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
@@ -181,8 +175,6 @@ namespace System.Text
 
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-
             if (chars == null || bytes == null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -246,8 +238,6 @@ namespace System.Text
 
         public override unsafe int GetBytes(string s, int charIndex, int charCount, byte[] bytes, int byteIndex)
         {
-            // Validate Parameters
-
             if (s is null || bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -326,8 +316,6 @@ namespace System.Text
 
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-
             if (bytes == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes);
@@ -353,8 +341,6 @@ namespace System.Text
 
         public override int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate input parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
@@ -407,8 +393,6 @@ namespace System.Text
 
         public unsafe override int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-
             if (bytes is null || chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -453,8 +437,6 @@ namespace System.Text
 
         public unsafe override int GetChars(byte[] bytes, int byteIndex, int byteCount, char[] chars, int charIndex)
         {
-            // Validate Parameters
-
             if (bytes is null || chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -488,8 +470,6 @@ namespace System.Text
 
         public unsafe override char[] GetChars(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -554,8 +534,6 @@ namespace System.Text
 
         public unsafe override string GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF32Encoding.cs
@@ -94,7 +94,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -117,7 +116,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(string s)
         {
-            // Validate input
             if (s == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
@@ -136,7 +134,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -221,7 +218,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -240,7 +236,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -265,7 +260,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -283,7 +277,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (byteIndex < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(byteIndex < 0 ? nameof(byteIndex) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -315,7 +308,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -334,7 +326,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF7Encoding.cs
@@ -137,7 +137,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -160,7 +159,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(string s)
         {
-            // Validate input
             if (s == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
@@ -179,7 +177,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -264,7 +261,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -283,7 +279,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -308,7 +303,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -326,7 +320,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (byteIndex < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(byteIndex < 0 ? nameof(byteIndex) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -358,7 +351,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -377,7 +369,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UTF8Encoding.cs
@@ -128,8 +128,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(char[] chars, int index, int count)
         {
-            // Validate input parameters
-
             if (chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars, ExceptionResource.ArgumentNull_Array);
@@ -158,8 +156,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(string chars)
         {
-            // Validate input parameters
-
             if (chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars);
@@ -178,8 +174,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetByteCount(char* chars, int count)
         {
-            // Validate Parameters
-
             if (chars == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.chars);
@@ -261,8 +255,6 @@ namespace System.Text
         public override unsafe int GetBytes(string s, int charIndex, int charCount,
                                               byte[] bytes, int byteIndex)
         {
-            // Validate Parameters
-
             if (s is null || bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -349,8 +341,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetBytes(char* chars, int charCount, byte* bytes, int byteCount)
         {
-            // Validate Parameters
-
             if (chars == null || bytes == null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -431,8 +421,6 @@ namespace System.Text
 
         public override unsafe int GetCharCount(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
@@ -461,8 +449,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetCharCount(byte* bytes, int count)
         {
-            // Validate Parameters
-
             if (bytes == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);
@@ -494,8 +480,6 @@ namespace System.Text
         public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                               char[] chars, int charIndex)
         {
-            // Validate Parameters
-
             if (bytes is null || chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -534,8 +518,6 @@ namespace System.Text
         [CLSCompliant(false)]
         public override unsafe int GetChars(byte* bytes, int byteCount, char* chars, int charCount)
         {
-            // Validate Parameters
-
             if (bytes is null || chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(
@@ -658,8 +640,6 @@ namespace System.Text
 
         public override unsafe string GetString(byte[] bytes, int index, int count)
         {
-            // Validate Parameters
-
             if (bytes is null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.bytes, ExceptionResource.ArgumentNull_Array);

--- a/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Text/UnicodeEncoding.cs
@@ -86,7 +86,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate input parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -109,7 +108,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(string s)
         {
-            // Validate input
             if (s == null)
             {
                 ThrowHelper.ThrowArgumentNullException(ExceptionArgument.s);
@@ -128,7 +126,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -213,7 +210,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(chars);
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -232,7 +228,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -257,7 +252,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -275,7 +269,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (byteIndex < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(byteIndex < 0 ? nameof(byteIndex) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -307,7 +300,6 @@ namespace System.Text
             ArgumentNullException.ThrowIfNull(bytes);
             ArgumentNullException.ThrowIfNull(chars);
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException(charCount < 0 ? nameof(charCount) : nameof(byteCount), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -326,7 +318,6 @@ namespace System.Text
         {
             ArgumentNullException.ThrowIfNull(bytes);
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException(index < 0 ? nameof(index) : nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 

--- a/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Threading/SemaphoreSlim.cs
@@ -154,7 +154,6 @@ namespace System.Threading
                     nameof(initialCount), initialCount, SR.SemaphoreSlim_ctor_InitialCountWrong);
             }
 
-            // validate input
             if (maxCount <= 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(maxCount), maxCount, SR.SemaphoreSlim_ctor_MaxCountWrong);
@@ -288,7 +287,6 @@ namespace System.Threading
         {
             CheckDispose();
 
-            // Validate input
             if (millisecondsTimeout < -1)
             {
                 throw new ArgumentOutOfRangeException(
@@ -599,7 +597,6 @@ namespace System.Threading
         {
             CheckDispose();
 
-            // Validate input
             if (millisecondsTimeout < -1)
             {
                 throw new ArgumentOutOfRangeException(
@@ -776,7 +773,6 @@ namespace System.Threading
         {
             CheckDispose();
 
-            // Validate input
             if (releaseCount < 1)
             {
                 throw new ArgumentOutOfRangeException(

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/ReadContentAsBinaryHelper.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/ReadContentAsBinaryHelper.cs
@@ -64,7 +64,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -118,7 +117,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -172,7 +170,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -226,7 +223,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingReader.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlCharCheckingReader.cs
@@ -480,7 +480,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -539,7 +538,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImpl.cs
@@ -1600,7 +1600,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -1658,7 +1657,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -1715,7 +1713,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -1773,7 +1770,6 @@ namespace System.Xml
         {
             ArgumentNullException.ThrowIfNull(buffer);
 
-            // check arguments
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -1842,8 +1838,9 @@ namespace System.Xml
             {
                 throw new InvalidOperationException(SR.Format(SR.Xml_InvalidReadValueChunk, _curNode.type));
             }
-            // check arguments
+
             ArgumentNullException.ThrowIfNull(buffer);
+
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));

--- a/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
+++ b/src/libraries/System.Private.Xml/src/System/Xml/Core/XmlTextReaderImplAsync.cs
@@ -387,8 +387,8 @@ namespace System.Xml
         public override Task<int> ReadContentAsBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            // check arguments
             ArgumentNullException.ThrowIfNull(buffer);
+
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -453,8 +453,8 @@ namespace System.Xml
         public override async Task<int> ReadContentAsBinHexAsync(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            // check arguments
             ArgumentNullException.ThrowIfNull(buffer);
+
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -528,8 +528,8 @@ namespace System.Xml
         public override Task<int> ReadElementContentAsBase64Async(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            // check arguments
             ArgumentNullException.ThrowIfNull(buffer);
+
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -594,8 +594,8 @@ namespace System.Xml
         public override async Task<int> ReadElementContentAsBinHexAsync(byte[] buffer, int index, int count)
         {
             CheckAsyncCall();
-            // check arguments
             ArgumentNullException.ThrowIfNull(buffer);
+
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
@@ -651,12 +651,13 @@ namespace System.Xml
         public override async Task<int> ReadValueChunkAsync(char[] buffer, int index, int count)
         {
             CheckAsyncCall();
+
             // throw on elements
             if (!XmlReader.HasValueInternal(_curNode.type))
             {
                 throw new InvalidOperationException(SR.Format(SR.Xml_InvalidReadValueChunk, _curNode.type));
             }
-            // check arguments
+
             ArgumentNullException.ThrowIfNull(buffer);
             if (count < 0)
             {

--- a/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
+++ b/src/libraries/System.Security.AccessControl/src/System/Security/AccessControl/ObjectSecurity.cs
@@ -434,9 +434,7 @@ namespace System.Security.AccessControl
 
         public virtual void PurgeAuditRules(IdentityReference identity)
         {
-
-ArgumentNullException.ThrowIfNull(identity);
-
+            ArgumentNullException.ThrowIfNull(identity);
 
             WriteLock();
 

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/DecoderNLS.cs
@@ -83,7 +83,6 @@ namespace System.Text
 
         public override unsafe int GetCharCount(byte[] bytes, int index, int count, bool flush)
         {
-            // Validate Parameters
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 
@@ -127,7 +126,6 @@ namespace System.Text
         public override unsafe int GetChars(byte[] bytes, int byteIndex, int byteCount,
                                             char[] chars, int charIndex, bool flush)
         {
-            // Validate Parameters
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 
@@ -225,7 +223,6 @@ namespace System.Text
                                             char* chars, int charCount, bool flush,
                                             out int bytesUsed, out int charsUsed, out bool completed)
         {
-            // Validate input parameters
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncoderNLS.cs
@@ -81,7 +81,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(char[] chars, int index, int count, bool flush)
         {
-            // Validate input parameters
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
@@ -106,7 +105,6 @@ namespace System.Text
 
         public override unsafe int GetByteCount(char* chars, int count, bool flush)
         {
-            // Validate input parameters
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
@@ -213,7 +211,6 @@ namespace System.Text
                                             byte* bytes, int byteCount, bool flush,
                                             out int charsUsed, out int bytesUsed, out bool completed)
         {
-            // Validate input parameters
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 

--- a/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
+++ b/src/libraries/System.Text.Encoding.CodePages/src/System/Text/EncodingNLS.cs
@@ -50,7 +50,6 @@ namespace System.Text
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
-            // Validate input parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -85,7 +84,6 @@ namespace System.Text
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -185,7 +183,6 @@ namespace System.Text
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException((charCount < 0 ? nameof(charCount) : nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -203,7 +200,6 @@ namespace System.Text
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -226,7 +222,6 @@ namespace System.Text
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 
-            // Validate Parameters
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -245,7 +240,6 @@ namespace System.Text
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
-            // Validate Parameters
             if (byteIndex < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException((byteIndex < 0 ? nameof(byteIndex) : nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -283,7 +277,6 @@ namespace System.Text
             if (chars is null)
                 throw new ArgumentNullException(nameof(chars));
 
-            // Validate Parameters
             if (charCount < 0 || byteCount < 0)
                 throw new ArgumentOutOfRangeException((charCount < 0 ? nameof(charCount) : nameof(byteCount)), SR.ArgumentOutOfRange_NeedNonNegNum);
 
@@ -301,7 +294,6 @@ namespace System.Text
             if (bytes is null)
                 throw new ArgumentNullException(nameof(bytes));
 
-            // Validate Parameters
             if (index < 0 || count < 0)
                 throw new ArgumentOutOfRangeException((index < 0 ? nameof(index) : nameof(count)), SR.ArgumentOutOfRange_NeedNonNegNum);
 

--- a/src/libraries/System.Threading/src/System/Threading/Barrier.cs
+++ b/src/libraries/System.Threading/src/System/Threading/Barrier.cs
@@ -421,10 +421,8 @@ namespace System.Threading
         /// disposed.</exception>
         public void RemoveParticipants(int participantCount)
         {
-            // check dispose
             ThrowIfDisposed();
 
-            // Validate input
             if (participantCount < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(participantCount), participantCount,


### PR DESCRIPTION
I stopped leaving comments on the unnecessary/somewhat-out-of-place comments about argument validation. Instead, I did a search myself to remove them. This also addresses [the spacing comment](https://github.com/dotnet/runtime/pull/68178#discussion_r854921697) I left. This does not address the `XmlCharCheckingReaderAsync` [comment](https://github.com/dotnet/runtime/pull/68178#discussion_r854898761) or the `InterpretedFrame` [comment](https://github.com/dotnet/runtime/pull/68178#discussion_r854807202).

I sent this as a PR to your branch so that you can easily use your discretion whether or not to accept the suggestions.